### PR TITLE
iCRMのインスタンスの設定時間を変更

### DIFF
--- a/redmine/Dockerfile
+++ b/redmine/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:focal
 LABEL MAINTENER shintaro.tanaka<shintaro.tanaka@ietty.co.jp>
 
 ENV TERM=xterm \
-    TZ=Asia/Tokyo
+    TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 ENV RUBY_VERSION=2.7.2 \


### PR DESCRIPTION
### PR概要
- docker imageを更新した際にubuntuの時刻設定がJSTになってしまったので、UTCに変更します

### 関連PR
https://github.com/ietty/ietty_crm_plugins/pull/84